### PR TITLE
fix: set evdi dependency to <1.15

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = displaylink
 	pkgdesc = Linux driver for DL-6xxx, DL-5xxx, DL-41xx and DL-3x00
 	pkgver = 5.8
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.synaptics.com/products/displaylink-graphics
 	changelog = displaylink-release-notes-5.8.txt
 	arch = i686
@@ -16,7 +16,7 @@ pkgbase = displaylink
 	makedepends = grep
 	makedepends = gawk
 	makedepends = wget
-	depends = evdi
+	depends = evdi<1.15.0
 	depends = libusb
 	source = displaylink-driver-5.8.zip::https://www.synaptics.com/sites/default/files/exe_files/2023-08/DisplayLink%20USB%20Graphics%20Software%20for%20Ubuntu5.8-EXE.zip
 	source = displaylink-release-notes-5.8.txt

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,12 +7,12 @@ pkgname=displaylink
 pkgver=5.8
 _releasedate=2023-08
 _pkgfullver=5.8.0-63.33
-pkgrel=1
+pkgrel=2
 pkgdesc="Linux driver for DL-6xxx, DL-5xxx, DL-41xx and DL-3x00"
 arch=('i686' 'x86_64' 'arm' 'armv6h' 'armv7h' 'aarch64')
 url="https://www.synaptics.com/products/displaylink-graphics"
 license=('custom' 'GPL2' 'LGPL2.1')
-depends=('evdi'
+depends=('evdi<1.15.0'
          'libusb')
 makedepends=('grep' 'gawk' 'wget')
 changelog="displaylink-release-notes-${pkgver}.txt"


### PR DESCRIPTION
avoids breaking the driver when `evdi` is updated
suggested by `endorfina` aur user in the out-of-date flag comment